### PR TITLE
Comma in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ By default, growls use the standard 'alert' Bootstrap style, are 250px wide, rig
 
 ```javascript
 $.bootstrapGrowl("another message, yay!", {
-  ele: 'body' // which element to append to
+  ele: 'body', // which element to append to
   type: 'info', // (null, 'info', 'error', 'success')
   offset: {from: 'top', amount: 20}, // 'top', or 'bottom'
   align: 'right', // ('left', 'right', or 'center')


### PR DESCRIPTION
It's _really_ minor, but there is a comma missing in README.md that gives you bugs when you copy/paste into your own app. It's bugged me a few times, so I thought I'd fix it and save someone else the trouble of dealing with it too.
