### PR TITLE
Composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "ifightcrime/bootstrap-growl",
+    "description": "Pretty simple jQuery plugin that turns standard Bootstrap alerts into 'Growl-like' notifications.",
+    "keywords": ["bootstrap", "growl", "notifications"],
+    "homepage": "https://github.com/ifightcrime/bootstrap-growl",
+    "author": "Nick Larson",
+    "license": "MIT"
+}


### PR DESCRIPTION
Adding `composer.json` to allow for Composer support for PHP projects. 
