### PR TITLE
Added fix for anything that uses hash based url router

### DIFF
--- a/jquery.bootstrap-growl.js
+++ b/jquery.bootstrap-growl.js
@@ -13,7 +13,7 @@
       $alert.addClass("alert-" + options.type);
     }
     if (options.allow_dismiss) {
-      $alert.append("<a class=\"close\" data-dismiss=\"alert\" href=\"#\">&times;</a>");
+      $alert.append("<span class=\"close\" data-dismiss=\"alert\">&times;</span>");
     }
     $alert.append(message);
     if (options.top_offset) {


### PR DESCRIPTION
If your using backbone / angular / ember etc... when you click the dismiss button the href="#" in the dismiss sends you to an unexpected route. This fixes that.
